### PR TITLE
Enhance CLI command structure and output options

### DIFF
--- a/src/workato_platform/cli/__init__.py
+++ b/src/workato_platform/cli/__init__.py
@@ -67,8 +67,11 @@ def cli(
 # Core setup and configuration commands
 cli.add_command(init.init)
 cli.add_command(projects.projects)
+cli.add_command(projects.projects, name="project")
 cli.add_command(profiles.profiles)
+cli.add_command(profiles.profiles, name="profiles")
 cli.add_command(properties.properties)
+cli.add_command(properties.properties, name="property")
 
 # Development commands
 cli.add_command(guide.guide)
@@ -77,12 +80,19 @@ cli.add_command(pull.pull)
 
 # API and resource management commands
 cli.add_command(api_collections.api_collections)
+cli.add_command(api_collections.api_collections, name="api-collection")
 cli.add_command(api_clients.api_clients)
+cli.add_command(api_clients.api_clients, name="api-client")
 cli.add_command(data_tables.data_tables)
+cli.add_command(data_tables.data_tables, name="data-table")
 cli.add_command(connections.connections)
+cli.add_command(connections.connections, name="connection")
 cli.add_command(connectors.connectors)
+cli.add_command(connectors.connectors, name="connector")
 cli.add_command(recipes.recipes)
+cli.add_command(recipes.recipes, name="recipe")
 
 # Information commands
 cli.add_command(assets.assets)
+cli.add_command(assets.assets, name="asset")
 cli.add_command(workspace.workspace)

--- a/tests/unit/commands/test_init.py
+++ b/tests/unit/commands/test_init.py
@@ -370,10 +370,6 @@ async def test_init_non_interactive_with_region_and_token(
 @pytest.mark.asyncio
 async def test_init_json_mode_without_non_interactive() -> None:
     """Test that JSON output mode requires non-interactive flag."""
-    import json
-
-    from io import StringIO
-
     output = StringIO()
 
     with patch.object(init_module.click, "echo", lambda msg: output.write(msg)):
@@ -398,10 +394,6 @@ async def test_init_json_mode_without_non_interactive() -> None:
 @pytest.mark.asyncio
 async def test_init_json_mode_with_validation_errors() -> None:
     """Test that validation errors in JSON mode return proper JSON."""
-    import json
-
-    from io import StringIO
-
     output = StringIO()
 
     with patch.object(init_module.click, "echo", lambda msg: output.write(msg)):
@@ -637,10 +629,6 @@ async def test_init_json_output_mode_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test successful init with JSON output mode."""
-    import json
-
-    from io import StringIO
-
     mock_config_manager = Mock()
     mock_workato_client = Mock()
     workato_context = AsyncMock()

--- a/tests/unit/config/test_manager.py
+++ b/tests/unit/config/test_manager.py
@@ -211,7 +211,11 @@ class TestConfigManager:
         )
 
         manager = await ConfigManager.initialize(
-            tmp_path, profile_name="dev", region="us", api_token="token"
+            tmp_path,
+            profile_name="dev",
+            region="us",
+            api_token="token",
+            non_interactive=True,
         )
 
         assert isinstance(manager, ConfigManager)
@@ -379,7 +383,7 @@ class TestConfigManager:
         workspace_env = json.loads(
             (tmp_path / ".workatoenv").read_text(encoding="utf-8")
         )
-        assert workspace_env["project_path"] == "subdir"
+        assert workspace_env["project_path"] == "subdir/CustomProj"
         assert StubProjectManager.created_projects[-1].name == "CustomProj"
 
     @pytest.mark.asyncio

--- a/tests/unit/utils/test_exception_handler.py
+++ b/tests/unit/utils/test_exception_handler.py
@@ -446,3 +446,198 @@ class TestExceptionHandler:
         # Should handle non-string errors gracefully
         result = _extract_error_details(exc)
         assert "Validation error:" in result
+
+    # JSON output mode tests
+    @patch("workato_platform.cli.utils.exception_handler.click.echo")
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_json_output_bad_request(
+        self, mock_get_context: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        """Test JSON output for BadRequestException"""
+        from workato_platform.client.workato_api.exceptions import BadRequestException
+
+        # Mock Click context to return json output mode
+        mock_ctx = MagicMock()
+        mock_ctx.params = {"output_mode": "json"}
+        mock_get_context.return_value = mock_ctx
+
+        @handle_api_exceptions
+        def bad_request_json() -> None:
+            raise BadRequestException(status=400, reason="Bad request")
+
+        bad_request_json()
+
+        # Should output JSON
+        call_args = [call[0][0] for call in mock_echo.call_args_list]
+        assert any('{"status": "error"' in arg for arg in call_args)
+
+    @patch("workato_platform.cli.utils.exception_handler.click.echo")
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_json_output_unauthorized(
+        self, mock_get_context: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        """Test JSON output for UnauthorizedException"""
+        from workato_platform.client.workato_api.exceptions import UnauthorizedException
+
+        mock_ctx = MagicMock()
+        mock_ctx.params = {"output_mode": "json"}
+        mock_get_context.return_value = mock_ctx
+
+        @handle_api_exceptions
+        def unauthorized_json() -> None:
+            raise UnauthorizedException(status=401, reason="Unauthorized")
+
+        unauthorized_json()
+
+        call_args = [call[0][0] for call in mock_echo.call_args_list]
+        assert any('"error_code": "UNAUTHORIZED"' in arg for arg in call_args)
+
+    @patch("workato_platform.cli.utils.exception_handler.click.echo")
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_json_output_forbidden(
+        self, mock_get_context: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        """Test JSON output for ForbiddenException"""
+        from workato_platform.client.workato_api.exceptions import ForbiddenException
+
+        mock_ctx = MagicMock()
+        mock_ctx.params = {"output_mode": "json"}
+        mock_get_context.return_value = mock_ctx
+
+        @handle_api_exceptions
+        def forbidden_json() -> None:
+            raise ForbiddenException(status=403, reason="Forbidden")
+
+        forbidden_json()
+
+        call_args = [call[0][0] for call in mock_echo.call_args_list]
+        assert any('"error_code": "FORBIDDEN"' in arg for arg in call_args)
+
+    @patch("workato_platform.cli.utils.exception_handler.click.echo")
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_json_output_not_found(
+        self, mock_get_context: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        """Test JSON output for NotFoundException"""
+        from workato_platform.client.workato_api.exceptions import NotFoundException
+
+        mock_ctx = MagicMock()
+        mock_ctx.params = {"output_mode": "json"}
+        mock_get_context.return_value = mock_ctx
+
+        @handle_api_exceptions
+        def not_found_json() -> None:
+            raise NotFoundException(status=404, reason="Not found")
+
+        not_found_json()
+
+        call_args = [call[0][0] for call in mock_echo.call_args_list]
+        assert any('"error_code": "NOT_FOUND"' in arg for arg in call_args)
+
+    @patch("workato_platform.cli.utils.exception_handler.click.echo")
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_json_output_conflict(
+        self, mock_get_context: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        """Test JSON output for ConflictException"""
+        from workato_platform.client.workato_api.exceptions import ConflictException
+
+        mock_ctx = MagicMock()
+        mock_ctx.params = {"output_mode": "json"}
+        mock_get_context.return_value = mock_ctx
+
+        @handle_api_exceptions
+        def conflict_json() -> None:
+            raise ConflictException(status=409, reason="Conflict")
+
+        conflict_json()
+
+        call_args = [call[0][0] for call in mock_echo.call_args_list]
+        assert any('"error_code": "CONFLICT"' in arg for arg in call_args)
+
+    @patch("workato_platform.cli.utils.exception_handler.click.echo")
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_json_output_server_error(
+        self, mock_get_context: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        """Test JSON output for ServiceException"""
+        from workato_platform.client.workato_api.exceptions import ServiceException
+
+        mock_ctx = MagicMock()
+        mock_ctx.params = {"output_mode": "json"}
+        mock_get_context.return_value = mock_ctx
+
+        @handle_api_exceptions
+        def server_error_json() -> None:
+            raise ServiceException(status=500, reason="Server error")
+
+        server_error_json()
+
+        call_args = [call[0][0] for call in mock_echo.call_args_list]
+        assert any('"error_code": "SERVER_ERROR"' in arg for arg in call_args)
+
+    @patch("workato_platform.cli.utils.exception_handler.click.echo")
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_json_output_generic_api_error(
+        self, mock_get_context: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        """Test JSON output for generic ApiException"""
+        from workato_platform.client.workato_api.exceptions import ApiException
+
+        mock_ctx = MagicMock()
+        mock_ctx.params = {"output_mode": "json"}
+        mock_get_context.return_value = mock_ctx
+
+        @handle_api_exceptions
+        def generic_error_json() -> None:
+            raise ApiException(status=418, reason="I'm a teapot")
+
+        generic_error_json()
+
+        call_args = [call[0][0] for call in mock_echo.call_args_list]
+        assert any('"error_code": "API_ERROR"' in arg for arg in call_args)
+
+    @patch("workato_platform.cli.utils.exception_handler.click.echo")
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_json_output_with_error_details(
+        self, mock_get_context: MagicMock, mock_echo: MagicMock
+    ) -> None:
+        """Test JSON output includes error details from body"""
+        from workato_platform.client.workato_api.exceptions import BadRequestException
+
+        mock_ctx = MagicMock()
+        mock_ctx.params = {"output_mode": "json"}
+        mock_get_context.return_value = mock_ctx
+
+        @handle_api_exceptions
+        def with_details_json() -> None:
+            raise BadRequestException(
+                status=400, body='{"message": "Field validation failed"}'
+            )
+
+        with_details_json()
+
+        call_args = [call[0][0] for call in mock_echo.call_args_list]
+        assert any("Field validation failed" in arg for arg in call_args)
+
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_get_output_mode_no_context(self, mock_get_context: MagicMock) -> None:
+        """Test _get_output_mode returns 'table' when no context"""
+        from workato_platform.cli.utils.exception_handler import _get_output_mode
+
+        mock_get_context.return_value = None
+
+        result = _get_output_mode()
+        assert result == "table"
+
+    @patch("workato_platform.cli.utils.exception_handler.click.get_current_context")
+    def test_get_output_mode_no_params(self, mock_get_context: MagicMock) -> None:
+        """Test _get_output_mode returns 'table' when context has no params"""
+        from workato_platform.cli.utils.exception_handler import _get_output_mode
+
+        mock_ctx = MagicMock()
+        del mock_ctx.params  # Remove params attribute
+        mock_get_context.return_value = mock_ctx
+
+        result = _get_output_mode()
+        assert result == "table"


### PR DESCRIPTION
- Added aliases for existing commands in the CLI for improved usability, allowing commands like `project`, `profiles`, and `property` to be recognized alongside their original names.
- Introduced an `--output-mode` option in the `init` and `status` commands to support both table and JSON formats, enhancing user experience and data accessibility.
- Implemented validation to ensure JSON output mode is only used in non-interactive mode, providing clear error messages for incorrect usage.
- Updated error handling in the `init` command to return structured JSON responses for various validation errors, improving consistency in user feedback.
- Enhanced unit tests to cover new output modes and validation scenarios, ensuring robust functionality and error handling across commands.