### PR TITLE
Add missing trial and il regions to non-interactive init

### DIFF
--- a/src/workato_platform/cli/commands/init.py
+++ b/src/workato_platform/cli/commands/init.py
@@ -14,7 +14,7 @@ from workato_platform.client.workato_api.configuration import Configuration
 @click.option("--profile", help="Profile name to use (creates new if doesn't exist)")
 @click.option(
     "--region",
-    type=click.Choice(["us", "eu", "jp", "au", "sg", "custom"]),
+    type=click.Choice(["us", "eu", "jp", "au", "sg", "il", "trial", "custom"]),
     help="Workato region",
 )
 @click.option("--api-token", help="Workato API token")


### PR DESCRIPTION
The --region option in non-interactive mode was missing the 'trial' and 'il' regions that are available in interactive mode. This caused inconsistency between the two modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)