### PR TITLE
Fix command listing to show only main commands, hiding singular aliases

### DIFF
--- a/src/workato_platform/cli/__init__.py
+++ b/src/workato_platform/cli/__init__.py
@@ -45,6 +45,8 @@ class AliasedGroup(click.Group):
         # Store alias mapping
         if alias:
             main_name = name or cmd.name
+            if not main_name:
+                raise ValueError("Command must have a name to create an alias")
             if alias == main_name:
                 raise ValueError(
                     f"Alias '{alias}' cannot be the same as "
@@ -55,9 +57,7 @@ class AliasedGroup(click.Group):
     def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
         # Check if it's an alias first
         if cmd_name in self.aliases:
-            aliased_name = self.aliases[cmd_name]
-            if aliased_name is not None:
-                cmd_name = aliased_name
+            cmd_name = self.aliases[cmd_name]
         return super().get_command(ctx, cmd_name)
 
 


### PR DESCRIPTION
This PR implements a custom Click group class to manage command aliases, ensuring only main commands appear in help output while keeping singular forms accessible as hidden aliases. The solution centralizes alias management through a new AliasedGroup class that maps aliases to their main commands internally.

Key changes:

Introduced AliasedGroup class with internal alias mapping and resolution
Replaced duplicate command registrations with add_command_with_alias() calls
Converted all plural-singular command pairs to use hidden aliases