### PR TITLE
Clarify --restart-recipes flag behavior and change default to false

### DIFF
--- a/docs/COMMAND_REFERENCE.md
+++ b/docs/COMMAND_REFERENCE.md
@@ -22,7 +22,7 @@ workato workspace
 workato init                        # Initialize CLI configuration
 workato workspace                   # Show current workspace info
 workato pull                       # Pull latest from remote
-workato push [--restart-recipes]   # Push local changes
+workato push [--restart-recipes]   # Push local changes (recipes won't restart by default)
 ```
 
 ### Recipe Management
@@ -86,7 +86,7 @@ workato init  # Creates profile interactively
 
 # Development
 workato recipes validate --path ./recipe.json
-workato push --restart-recipes
+workato push --restart-recipes  # Only restarts running recipes that were updated
 workato recipes list --running
 
 # Switch environments
@@ -117,7 +117,7 @@ workato connections get-oauth-url --id 789
 
 ## Environment Support
 
-**Trial Accounts:** Use `wrkatrial-` tokens with `https://app.trial.workato.com/api` 
+**Trial Accounts:** Use `wrkatrial-` tokens with `https://app.trial.workato.com/api`
 
 **Production Accounts:** Use `wrkprod-` tokens with `https://www.workato.com/api`
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -14,7 +14,7 @@ Build and validate integration recipes locally before deployment to avoid produc
 #### Commands
 ```bash
 workato recipes validate --path ./recipes/salesforce-sync.json
-workato push --restart-recipes
+workato push --restart-recipes  # Only restarts running recipes that were updated
 ```
 
 ### Multi-Environment Management
@@ -35,7 +35,7 @@ workato push
 # Staging
 workato profiles use staging
 workato pull
-workato push --restart-recipes
+workato push --restart-recipes  # Only restarts running recipes that were updated
 
 # Production
 workato profiles use production
@@ -75,7 +75,7 @@ Automate recipe deployment as part of build and release pipelines.
 ```bash
 # In CI pipeline
 workato recipes validate --path ./recipes/*.json
-workato push --restart-recipes --include-tags
+workato push --restart-recipes --include-tags  # Only restarts running recipes that were updated
 ```
 
 ### Recipe Lifecycle Management

--- a/src/workato_platform_cli/cli/commands/push/command.py
+++ b/src/workato_platform_cli/cli/commands/push/command.py
@@ -60,7 +60,11 @@ STATUS_INFO = {
 
 @click.command()
 @click.option(
-    "--restart-recipes", is_flag=True, default=True, help="Restart recipes after import"
+    "--restart-recipes",
+    is_flag=True,
+    default=False,
+    help="Allow restarting of running recipes that are updated during import. "
+    "Stopped recipes will remain stopped.",
 )
 @click.option(
     "--include-tags", is_flag=True, default=True, help="Include tags in import"
@@ -68,7 +72,7 @@ STATUS_INFO = {
 @inject
 @handle_api_exceptions
 async def push(
-    restart_recipes: bool = True,
+    restart_recipes: bool = False,
     include_tags: bool = True,
     config_manager: ConfigManager = Provide[Container.config_manager],
 ) -> None:

--- a/tests/unit/commands/push/test_command.py
+++ b/tests/unit/commands/push/test_command.py
@@ -184,7 +184,7 @@ async def test_push_creates_zip_and_invokes_upload(
     assert upload_mock.await_count == 1
     call_kwargs = upload_calls[0]
     assert call_kwargs["folder_id"] == 777
-    assert call_kwargs["restart_recipes"] is True
+    assert call_kwargs["restart_recipes"] is False
     assert call_kwargs["include_tags"] is True
     assert not (tmp_path / "demo.zip").exists()
     assert any("Package created" in line for line in capture_echo)


### PR DESCRIPTION
## Summary
The `--restart-recipes` flag allows restarting of running recipes that are updated during import, but does not force stopped recipes to restart. This was not clear from the help text and documentation, leading to confusion about the expected behavior.

## Changes
- **Breaking change:** Changed default from `true` to `false` (more conservative approach)
- Updated help text to clarify that stopped recipes remain stopped
- Added inline comments in documentation (COMMAND_REFERENCE.md and USE_CASES.md)
- Updated test to reflect new default value

## Behavior
**Before:** `workato push` would allow recipe restarts by default  
**After:** `workato push` will NOT allow recipe restarts by default

Users who want to allow restarts must now explicitly use:
```bash
workato push --restart-recipes
```

This aligns with the Workato API's default behavior and makes the CLI more conservative by default.

## Testing
- ✅ All unit tests pass
- ✅ Ruff linter passed
- ✅ Mypy type checker passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)