### PR TITLE
Revert "Add visual feedback for API token input with asterisk masking"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,6 @@ repos:
             pytest>=7.0.0,
             pytest-asyncio>=0.21.0,
             pytest-mock>=3.10.0,
-            pwinput>=1.0.3,
           ]
         exclude: ^(client/|src/workato_platform/client/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "python-dateutil>=2.8.0",
     "typing-extensions>=4.0.0",
     "packaging>=21.0",
-    "pwinput>=1.0.3",
     "cbor2>=5.7.0",
     "certifi>=2025.8.3",
     "keyring>=25.6.0",
@@ -183,7 +182,6 @@ module = [
     "dependency_injector.*",
     "asyncclick.*",
     "keyring.*",
-    "pwinput.*",
 ]
 ignore_missing_imports = true
 

--- a/src/workato_platform_cli/cli/utils/config/manager.py
+++ b/src/workato_platform_cli/cli/utils/config/manager.py
@@ -10,7 +10,6 @@ from urllib.parse import urlparse
 import asyncclick as click
 import certifi
 import inquirer
-import pwinput
 
 from workato_platform_cli import Workato
 from workato_platform_cli.cli.commands.projects.project_manager import ProjectManager
@@ -339,18 +338,8 @@ class ConfigManager:
             )
 
         # Get API token
-        # Note: pwinput.pwinput() is called synchronously (not wrapped in
-        # asyncio.to_thread) because wrapping it causes terminal buffer issues
-        # when pasting long tokens. The async wrapper interferes with terminal
-        # input buffering, causing some characters to leak through before masking.
-        # Since this is a blocking user input operation anyway, there's no benefit
-        # to making it async.
-        #
-        # TODO: Once we upgrade to Python 3.14+, consider migrating to the built-in
-        # getpass.getpass(prompt="...", echo_char='*') which provides native masked
-        # input support without requiring the pwinput dependency.
         click.echo("🔐 Enter your API token")
-        token = pwinput.pwinput(prompt="Enter your Workato API token: ", mask="*")
+        token = await click.prompt("Enter your Workato API token", hide_input=True)
         if not token.strip():
             click.echo("❌ No token provided")
             sys.exit(1)

--- a/tests/unit/config/test_manager.py
+++ b/tests/unit/config/test_manager.py
@@ -1220,6 +1220,7 @@ class TestConfigManager:
 
         prompt_answers = {
             "Enter profile name": ["dev"],
+            "Enter your Workato API token": ["token-123"],
             "Enter project name": ["DemoProject"],
         }
 
@@ -1231,16 +1232,6 @@ class TestConfigManager:
         monkeypatch.setattr(
             ConfigManager.__module__ + ".click.prompt",
             fake_prompt,
-        )
-
-        # Mock pwinput for token input
-        def fake_pwinput(prompt: str, mask: str = "*") -> str:
-            assert "API token" in prompt
-            return "token-123"
-
-        monkeypatch.setattr(
-            ConfigManager.__module__ + ".pwinput.pwinput",
-            fake_pwinput,
         )
         monkeypatch.setattr(
             ConfigManager.__module__ + ".click.confirm",
@@ -1423,6 +1414,7 @@ class TestConfigManager:
 
         prompt_answers = {
             "Enter your custom Workato base URL": ["https://custom.workato.test"],
+            "Enter your Workato API token": ["custom-token"],
         }
 
         async def fake_prompt(message: str, **_: Any) -> str:
@@ -1433,16 +1425,6 @@ class TestConfigManager:
         monkeypatch.setattr(
             ConfigManager.__module__ + ".click.prompt",
             fake_prompt,
-        )
-
-        # Mock pwinput for token input
-        def fake_pwinput(prompt: str, mask: str = "*") -> str:
-            assert "API token" in prompt
-            return "custom-token"
-
-        monkeypatch.setattr(
-            ConfigManager.__module__ + ".pwinput.pwinput",
-            fake_pwinput,
         )
 
         def custom_region_prompt(questions: list[Any]) -> dict[str, str]:
@@ -1504,13 +1486,14 @@ class TestConfigManager:
             lambda _questions: {"region": "US Data Center (https://www.workato.com)"},
         )
 
-        # Mock pwinput to return blank token
-        def fake_pwinput(prompt: str, mask: str = "*") -> str:
-            return "   "
+        async def fake_prompt(message: str, **_: Any) -> str:
+            if "API token" in message:
+                return "   "
+            return "unused"
 
         monkeypatch.setattr(
-            ConfigManager.__module__ + ".pwinput.pwinput",
-            fake_pwinput,
+            ConfigManager.__module__ + ".click.prompt",
+            fake_prompt,
         )
 
         with pytest.raises(SystemExit):

--- a/uv.lock
+++ b/uv.lock
@@ -1222,12 +1222,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pwinput"
-version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4b/c9/f6d03c2214c282251baa38c6be08f5b9f81f1ea488716cd2335e7e190b58/pwinput-1.0.3.tar.gz", hash = "sha256:ca1a8bd06e28872d751dbd4132d8637127c25b408ea3a349377314a5491426f3", size = 4433, upload-time = "2023-02-16T17:04:14.592Z" }
-
-[[package]]
 name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1725,7 +1719,6 @@ dependencies = [
     { name = "inquirer" },
     { name = "keyring" },
     { name = "packaging" },
-    { name = "pwinput" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "ruff" },
@@ -1783,7 +1776,6 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "packaging", specifier = ">=21.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
-    { name = "pwinput", specifier = ">=1.0.3" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },


### PR DESCRIPTION
I have run into issues pasting long length (750+char) API keys - it appears that it is getting truncated. 

I believe this  is caused by terminal emulator input buffer limitations, not the `pwinput` library itself. The `pwinput` library processes input character-by-character using `getch()`, which makes it vulnerable to terminal paste buffer limits.

Lets push this improvement out to a later release.

Reverts workato-devs/workato-platform-cli#28