### PR TITLE
Fix test isolation by clearing WORKATO_* environment variables

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,12 @@ def isolate_tests(monkeypatch: pytest.MonkeyPatch, temp_config_dir: Path) -> Non
     # Ensure we don't make real API calls
     monkeypatch.setenv("WORKATO_TEST_MODE", "1")
 
+    # Clear environment variables that tests expect to control explicitly
+    # This prevents shell environment from affecting test behavior
+    monkeypatch.delenv("WORKATO_API_TOKEN", raising=False)
+    monkeypatch.delenv("WORKATO_HOST", raising=False)
+    monkeypatch.delenv("WORKATO_PROFILE", raising=False)
+
     # Note: Keyring mocking is handled by individual test fixtures when needed
 
     # Mock Path.home() to use temp directory for ProfileManager


### PR DESCRIPTION
## Summary

- Fixed test isolation issue where tests failed when WORKATO_API_TOKEN, WORKATO_HOST, or WORKATO_PROFILE environment variables were set in the shell
- Updated the `isolate_tests` fixture in `tests/conftest.py` to clear these environment variables before running tests
- This ensures tests are properly isolated from the developer's shell environment

## Changes

- Added `monkeypatch.delenv()` calls in the `isolate_tests` fixture to clear WORKATO_API_TOKEN, WORKATO_HOST, and WORKATO_PROFILE environment variables
- Tests can still explicitly set these variables when needed for specific test scenarios

## Test plan

- [x] Verified the specific failing test now passes
- [x] Ran all 130 tests in affected test files with environment variables set - all pass
- [x] Ran full test suite (919 tests) with all three environment variables exported - all pass
- [x] Verified type checker (mypy), linter (ruff), and formatter pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)