### PR TITLE
Add support for agentic asset types

### DIFF
--- a/src/workato_platform_cli/client/workato_api/models/asset.py
+++ b/src/workato_platform_cli/client/workato_api/models/asset.py
@@ -42,8 +42,8 @@ class Asset(BaseModel):
     @field_validator('type')
     def type_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['recipe', 'connection', 'lookup_table', 'workato_db_table', 'account_property', 'project_property', 'workato_schema', 'workato_template', 'lcap_app', 'lcap_page', 'custom_adapter', 'topic', 'api_group', 'api_endpoint']):
-            raise ValueError("must be one of enum values ('recipe', 'connection', 'lookup_table', 'workato_db_table', 'account_property', 'project_property', 'workato_schema', 'workato_template', 'lcap_app', 'lcap_page', 'custom_adapter', 'topic', 'api_group', 'api_endpoint')")
+        if value not in set(['recipe', 'connection', 'lookup_table', 'workato_db_table', 'account_property', 'project_property', 'workato_schema', 'workato_template', 'lcap_app', 'lcap_page', 'custom_adapter', 'topic', 'api_group', 'api_endpoint', 'agentic_genie', 'agentic_skill', 'data_pipeline', 'decision_engine_model', 'agentic_knowledge_base']):
+            raise ValueError("must be one of enum values ('recipe', 'connection', 'lookup_table', 'workato_db_table', 'account_property', 'project_property', 'workato_schema', 'workato_template', 'lcap_app', 'lcap_page', 'custom_adapter', 'topic', 'api_group', 'api_endpoint', 'agentic_genie', 'agentic_skill', 'data_pipeline', 'decision_engine_model', 'agentic_knowledge_base')")
         return value
 
     @field_validator('status')

--- a/src/workato_platform_cli/client/workato_api/models/asset_reference.py
+++ b/src/workato_platform_cli/client/workato_api/models/asset_reference.py
@@ -40,8 +40,8 @@ class AssetReference(BaseModel):
     @field_validator('type')
     def type_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['recipe', 'connection', 'lookup_table', 'workato_db_table', 'account_property', 'project_property', 'workato_schema', 'workato_template', 'lcap_app', 'lcap_page', 'custom_adapter', 'topic', 'api_group', 'api_endpoint']):
-            raise ValueError("must be one of enum values ('recipe', 'connection', 'lookup_table', 'workato_db_table', 'account_property', 'project_property', 'workato_schema', 'workato_template', 'lcap_app', 'lcap_page', 'custom_adapter', 'topic', 'api_group', 'api_endpoint')")
+        if value not in set(['recipe', 'connection', 'lookup_table', 'workato_db_table', 'account_property', 'project_property', 'workato_schema', 'workato_template', 'lcap_app', 'lcap_page', 'custom_adapter', 'topic', 'api_group', 'api_endpoint', 'agentic_genie', 'agentic_skill', 'data_pipeline', 'decision_engine_model', 'agentic_knowledge_base']):
+            raise ValueError("must be one of enum values ('recipe', 'connection', 'lookup_table', 'workato_db_table', 'account_property', 'project_property', 'workato_schema', 'workato_template', 'lcap_app', 'lcap_page', 'custom_adapter', 'topic', 'api_group', 'api_endpoint', 'agentic_genie', 'agentic_skill', 'data_pipeline', 'decision_engine_model', 'agentic_knowledge_base')")
         return value
 
     model_config = ConfigDict(

--- a/workato-api-spec.yaml
+++ b/workato-api-spec.yaml
@@ -1698,6 +1698,11 @@ components:
               topic,
               api_group,
               api_endpoint,
+              agentic_genie,
+              agentic_skill,
+              data_pipeline,
+              decision_engine_model,
+              agentic_knowledge_base,
             ]
           example: "recipe"
         version:
@@ -1804,6 +1809,11 @@ components:
               topic,
               api_group,
               api_endpoint,
+              agentic_genie,
+              agentic_skill,
+              data_pipeline,
+              decision_engine_model,
+              agentic_knowledge_base,
             ]
         checked:
           type: boolean


### PR DESCRIPTION
Added 5 new agentic asset types to workato-api-spec.yaml:
- agentic_genie
- agentic_skill
- data_pipeline
- decision_engine_model
- agentic_knowledge_base

Updated Asset and AssetReference Pydantic models to accept the new types.

TESTING PLAN:
Added a genie to a project and performed `workato pull` instead of an error the project is now able to be built with the agentic asset. Attached the before/after result.

<img width="1728" height="124" alt="Screenshot 2026-01-05 at 11 35 47 AM" src="https://github.com/user-attachments/assets/d46b958e-599a-40ec-917c-90c98ceacef5" />
<img width="1727" height="124" alt="Screenshot 2026-01-05 at 11 36 01 AM" src="https://github.com/user-attachments/assets/916a728d-926a-470b-8f0d-3a73b82e4f72" />


Fixes DEVP-625