### PR TITLE
Devp 863 fix assets folder id validation

### DIFF
--- a/src/workato_platform_cli/cli/commands/assets.py
+++ b/src/workato_platform_cli/cli/commands/assets.py
@@ -15,7 +15,9 @@ from workato_platform_cli.client.workato_api.models.asset import Asset
 
 @click.command()
 @click.option(
-    "--folder-id", help="Folder ID (uses current project folder if not specified)"
+    "--folder-id",
+    type=int,
+    help="Folder ID (uses current project folder if not specified)",
 )
 @handle_cli_exceptions
 @inject


### PR DESCRIPTION
Validate the input from terminal is type int as required by the function that utilizes the argument