### PR TITLE
DEVP-650: Fix PyPI version control to resolve conflicts

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -66,7 +66,7 @@ jobs:
             echo "Development version: $VERSION"
           else
             # Production environment: get clean version from tags
-            VERSION=$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//' || echo "")
+            VERSION=$(git describe --tags --exact-match 2>/dev/null | sed 's/^v//')
             if [[ -z "$VERSION" ]]; then
               echo "Error: Production releases require an exact git tag"
               exit 1


### PR DESCRIPTION
- Replace GitHub run_number with hatch version for test deployments
- Remove SETUPTOOLS_SCM_PRETEND_VERSION override
- Use git-based semantic versioning from hatch-vcs
- Require exact git tags for production releases

Resolves version inconsistencies between local and PyPI deployments.