### PR TITLE
Fix connections create-oauth validation errors

### DIFF
--- a/src/workato_platform_cli/cli/commands/connections.py
+++ b/src/workato_platform_cli/cli/commands/connections.py
@@ -260,6 +260,7 @@ async def create(
 @connections.command(name="create-oauth")
 @click.option(
     "--parent-id",
+    type=int,
     required=True,
     help="ID of the parent OAuth connection (must be established/authorized)",
 )
@@ -269,7 +270,11 @@ async def create(
     type=int,
     help="ID of the project/folder (uses current project if not specified)",
 )
-@click.option("--external-id", help="End user string ID for identifying the connection")
+@click.option(
+    "--external-id",
+    required=True,
+    help="End user string ID for identifying the connection",
+)
 @click.option(
     "--callback-url",
     help="URL called back after successful token acquisition (optional)",


### PR DESCRIPTION
- Add type=int to --parent-id to ensure proper conversion from CLI string to integer
- Add required=True to --external-id since it's not optional in the function signature

Fixes validation errors:
- parent_id: Input should be a valid integer [type=int_type, input_value='92', input_type=str]
- external_id: Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]