### PR TITLE
fix(validator): change format_version type from str to int

### DIFF
--- a/src/workato_platform_cli/cli/commands/api_clients.py
+++ b/src/workato_platform_cli/cli/commands/api_clients.py
@@ -576,8 +576,9 @@ def display_client_summary(client: ApiClient) -> None:
     click.echo(f"    🔐 Auth Type: {client.auth_type}")
 
     # Show API collections if available
-    for collection in client.api_collections:
-        click.echo(f"    📚 {collection.name} (ID: {collection.id})")
+    if client.api_collections:
+        for collection in client.api_collections:
+            click.echo(f"    📚 {collection.name} (ID: {collection.id})")
 
     # Show email if available (API portal integration)
     if client.email:

--- a/src/workato_platform_cli/cli/commands/connections.py
+++ b/src/workato_platform_cli/cli/commands/connections.py
@@ -939,7 +939,9 @@ def pick_lists(adapter: str | None = None) -> None:
     """List available pick lists by adapter"""
 
     # Load the bundled picklist data
-    data_file = Path(__file__).parent.parent / "resources" / "data" / "picklist-data.json"
+    data_file = (
+        Path(__file__).parent.parent / "resources" / "data" / "picklist-data.json"
+    )
 
     if not data_file.exists():
         click.echo(

--- a/src/workato_platform_cli/cli/commands/connections.py
+++ b/src/workato_platform_cli/cli/commands/connections.py
@@ -939,7 +939,7 @@ def pick_lists(adapter: str | None = None) -> None:
     """List available pick lists by adapter"""
 
     # Load the bundled picklist data
-    data_file = Path(__file__).parent.parent / "data" / "picklist-data.json"
+    data_file = Path(__file__).parent.parent / "resources" / "data" / "picklist-data.json"
 
     if not data_file.exists():
         click.echo(

--- a/src/workato_platform_cli/cli/commands/recipes/validator.py
+++ b/src/workato_platform_cli/cli/commands/recipes/validator.py
@@ -110,7 +110,7 @@ class RecipeLine(BaseModel):
     clear_scope: bool | None = Field(None, alias="clear_scope")
     repeat_mode: str | None = Field(None, alias="repeat_mode")
     source: str | None = None
-    format_version: str | None = Field(None, alias="format_version")
+    format_version: int | None = Field(None, alias="format_version")
     job_report_config: dict[str, Any] | None = None
     job_report_schema: list[dict[str, Any]] | None = None
     param: dict[str, Any] | None = None

--- a/src/workato_platform_cli/client/workato_api/models/api_client.py
+++ b/src/workato_platform_cli/client/workato_api/models/api_client.py
@@ -45,8 +45,8 @@ class ApiClient(BaseModel):
     mtls_enabled: Optional[StrictBool] = None
     validation_formula: Optional[StrictStr] = None
     cert_bundle_ids: Optional[List[StrictInt]] = None
-    api_policies: List[ApiClientApiPoliciesInner] = Field(description="List of API policies associated with the client")
-    api_collections: List[ApiClientApiCollectionsInner] = Field(description="List of API collections associated with the client")
+    api_policies: Optional[List[ApiClientApiPoliciesInner]] = Field(default=None, description="List of API policies associated with the client")
+    api_collections: Optional[List[ApiClientApiCollectionsInner]] = Field(default=None, description="List of API collections associated with the client")
     __properties: ClassVar[List[str]] = ["id", "name", "description", "active_api_keys_count", "total_api_keys_count", "created_at", "updated_at", "logo", "logo_2x", "is_legacy", "email", "auth_type", "api_token", "mtls_enabled", "validation_formula", "cert_bundle_ids", "api_policies", "api_collections"]
 
     @field_validator('auth_type')

--- a/src/workato_platform_cli/client/workato_api/models/api_collection.py
+++ b/src/workato_platform_cli/client/workato_api/models/api_collection.py
@@ -18,8 +18,8 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from workato_platform_cli.client.workato_api.models.import_results import ImportResults
 from typing import Optional, Set
 from typing_extensions import Self
@@ -30,7 +30,7 @@ class ApiCollection(BaseModel):
     """ # noqa: E501
     id: StrictInt
     name: StrictStr
-    project_id: StrictStr
+    project_id: Optional[Union[StrictStr, StrictInt]] = None
     url: StrictStr
     api_spec_url: StrictStr
     version: StrictStr
@@ -39,6 +39,14 @@ class ApiCollection(BaseModel):
     message: Optional[StrictStr] = Field(default=None, description="Only present in creation/import responses")
     import_results: Optional[ImportResults] = None
     __properties: ClassVar[List[str]] = ["id", "name", "project_id", "url", "api_spec_url", "version", "created_at", "updated_at", "message", "import_results"]
+
+    @field_validator('project_id', mode='before')
+    @classmethod
+    def coerce_project_id_to_string(cls, v):
+        """Coerce project_id to string since API may return int or string"""
+        if v is not None:
+            return str(v)
+        return v
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/tests/unit/commands/connections/test_helpers.py
+++ b/tests/unit/commands/connections/test_helpers.py
@@ -269,7 +269,7 @@ def test_pick_lists(
     expected: str,
 ) -> None:
     module_root = tmp_path / "cli" / "commands"
-    data_dir = module_root.parent / "data"
+    data_dir = module_root.parent / "resources" / "data"
     data_dir.mkdir(parents=True)
 
     picklist_file = data_dir / "picklist-data.json"
@@ -320,7 +320,7 @@ def test_pick_lists_invalid_json(
     monkeypatch: pytest.MonkeyPatch, capture_echo: list[str], tmp_path: Path
 ) -> None:
     module_root = tmp_path / "cli" / "commands"
-    data_dir = module_root.parent / "data"
+    data_dir = module_root.parent / "resources" / "data"
     data_dir.mkdir(parents=True)
     invalid_file = data_dir / "picklist-data.json"
     invalid_file.write_text("not-json")

--- a/tests/unit/commands/recipes/test_validator.py
+++ b/tests/unit/commands/recipes/test_validator.py
@@ -119,6 +119,17 @@ def test_recipe_line_limits_job_report_entries() -> None:
         )
 
 
+def test_recipe_line_accepts_format_version_as_int() -> None:
+    """format_version is exported as integer by Workato API."""
+    line = RecipeLine(
+        number=0,
+        keyword=Keyword.TRIGGER,
+        uuid="test-uuid",
+        format_version=2,
+    )
+    assert line.format_version == 2
+
+
 def test_is_expression_detects_formulas_jinja_and_data_pills(
     validator: RecipeValidator,
 ) -> None:


### PR DESCRIPTION
## Summary

This PR fixes several validation bugs discovered during CLI testing.

## Fixes

### 1. RecipeValidator `format_version` type mismatch

The Workato export package API returns `format_version` as an integer (`2`), not a string. This caused false validation errors for all exported recipes.

**Error:**
❌ Recipe validation failed Message: Recipe parsing failed: format_version should be string not int Type: syntax_invalid


**Root Cause:** The `RecipeLine` Pydantic model defined `format_version` as `str | None`, but the API returns an integer.

**Fix:** Changed the type from `str | None` to `int | None` to match the actual API response.

### 2. `api-collections list` ValidationError

The API returns `project_id` as an integer or null, but the model expected a string.

**Error:**
ValidationError: 1 validation error for ApiCollection project_id: Input should be a valid string


**Fix:** Made `project_id` optional and added a validator to coerce int to string.

### 3. `api-clients list` ValidationError

The API can return `null` for `api_policies` and `api_collections`, but the model required non-null lists.

**Error:**
ValidationError: 1 validation error for ApiClient api_policies: Input should be a valid list


**Fix:** Made `api_policies` and `api_collections` optional with `default=None`.

### 4. `connections pick-lists` command path error

The path to `picklist-data.json` was incorrect (`cli/data` instead of `cli/resources/data`).

**Error:**
Picklist data not found. Run 'python scripts/parse_picklist_docs.py' to generate it.


**Fix:** Corrected the path to `cli/resources/data`.

## Testing

- Added unit test `test_recipe_line_accepts_format_version_as_int`
- Updated `test_helpers.py` to use correct data path
- Verified against 17 recipes exported from Workato - all now validate without errors
- All existing tests pass