### PR TITLE
fix: preserve non-ASCII filenames (e.g. Japanese) when extracting ZIP

### DIFF
--- a/src/workato_platform_cli/cli/commands/projects/project_manager.py
+++ b/src/workato_platform_cli/cli/commands/projects/project_manager.py
@@ -238,7 +238,7 @@ class ProjectManager:
             with open(zip_path, "wb") as f:
                 f.write(download_response)
 
-            with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            with zipfile.ZipFile(zip_path, "r", metadata_encoding="utf-8") as zip_ref:
                 zip_ref.extractall(project_dir)
 
             os.remove(zip_path)

--- a/tests/unit/commands/projects/test_project_manager.py
+++ b/tests/unit/commands/projects/test_project_manager.py
@@ -270,6 +270,51 @@ async def test_download_and_extract_package_success(
 
 
 @pytest.mark.asyncio
+async def test_download_and_extract_package_preserves_non_ascii_filenames(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ZIP files with non-ASCII filenames (e.g. Japanese) should be extracted correctly.
+
+    Python's zipfile defaults to CP437 for metadata decoding, which garbles
+    UTF-8 encoded filenames. metadata_encoding="utf-8" must be passed explicitly.
+    """
+    client = Mock()
+    client.packages_api = Mock()
+    client.packages_api.get_package = AsyncMock(return_value=Mock(status="completed"))
+
+    manager = ProjectManager(client)
+
+    monkeypatch.setattr("time.time", Mock(side_effect=[0, 10, 20]))
+    monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
+
+    target_dir = tmp_path / "project"
+    monkeypatch.chdir(tmp_path)
+
+    # Build a ZIP whose filename is stored as raw UTF-8 bytes (no UTF-8 flag),
+    # matching what the Workato API returns.
+    japanese_filename = "日本語レシピ_japanese.recipe.json"
+    zip_path = tmp_path / "dummy.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zip_info = zipfile.ZipInfo(japanese_filename)
+        zip_info.date_time = (2024, 1, 1, 0, 0, 0)
+        zip_info.flag_bits &= ~0x800  # Clear UTF-8 flag to simulate Workato API ZIP
+        zf.writestr(zip_info, "{}")
+    data = zip_path.read_bytes()
+
+    with patch.object(
+        manager.client.packages_api, "download_package", AsyncMock(return_value=data)
+    ):
+        result = await manager.download_and_extract_package(
+            12, target_dir=str(target_dir)
+        )
+
+    extracted_files = [f.name for f in target_dir.iterdir()]
+    assert japanese_filename in extracted_files, (
+        f"Expected '{japanese_filename}' but got: {extracted_files}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_download_and_extract_package_handles_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

When a recipe name contains non-ASCII characters (e.g. Japanese), the file extracted by `workato pull` becomes garbled.

**Example:**
- Recipe name: `日本語レシピ Japanese`
- Extracted filename: `µùÑµ£¼Φ¬₧πâ¼πé╖πâö_japanese.recipe.json` ❌

## Root Cause

Python's `zipfile` module defaults to **CP437** when decoding filenames from a ZIP archive. The Workato API returns ZIP files with UTF-8 encoded filenames (without the ZIP UTF-8 flag set), so the bytes get misinterpreted as CP437, producing garbled output.

## Fix

Pass `metadata_encoding="utf-8"` to the `ZipFile` constructor in `project_manager.py`:

```python
# Before
with zipfile.ZipFile(zip_path, "r") as zip_ref:
    zip_ref.extractall(project_dir)

# After
with zipfile.ZipFile(zip_path, "r", metadata_encoding="utf-8") as zip_ref:
    zip_ref.extractall(project_dir)
```

`metadata_encoding` was introduced in Python 3.11, which is already the minimum required version for this project.

## Result

- Recipe name: `日本語レシピ Japanese`
- Extracted filename: `日本語レシピ_japanese.recipe.json` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)